### PR TITLE
[codestyle] Fixed first letter casing in method names

### DIFF
--- a/Tests/Logger/DatabaseTest.php
+++ b/Tests/Logger/DatabaseTest.php
@@ -26,7 +26,7 @@ class DatabaseTest extends TestDatabase
 	 */
 	protected function getDataSet()
 	{
-		return $this->createXMLDataSet(__DIR__ . '/stubs/S01.xml');
+		return $this->createXmlDataSet(__DIR__ . '/stubs/S01.xml');
 	}
 
 	/**
@@ -82,7 +82,7 @@ class DatabaseTest extends TestDatabase
 		$logger = new Database($config);
 
 		// Get the expected database from XML.
-		$expected = $this->createXMLDataSet(__DIR__ . '/stubs/S01E01.xml');
+		$expected = $this->createXmlDataSet(__DIR__ . '/stubs/S01E01.xml');
 
 		// Add the new entries to the database.
 		$logger->addEntry(new LogEntry('Testing Entry 02', Log::INFO, null, '2009-12-01 12:30:00'));


### PR DESCRIPTION
This PR fixes some more method names to comply with the CamelCase rules mentioned here:
http://joomla.github.io/coding-standards/?coding-standards/chapters/php.md
> ...be written in CamelCase even if using traditionally uppercase acronyms (such as XML, HTML).